### PR TITLE
Feat/1/initial custom

### DIFF
--- a/docs/pol_alcoverro/initial-custom.md
+++ b/docs/pol_alcoverro/initial-custom.md
@@ -1,28 +1,40 @@
-# Informe de cambios: roles UX, Design, Wiki, Epics.
+# Informe de cambios — rama `feat/1/initial-custom`
 
-## Objetivo
-Ajustar la configuración inicial de los proyectos para que los roles **UX** y **Design** aparezcan con el toggle `help_role_enabled` deshabilitado al crear un nuevo proyecto. También hemos activado por defecto las épicas y desactivado la wiki en nuevos proyectos.
+## Resumen ejecutivo
+- Se enriquecen las plantillas iniciales con nuevos campos personalizados y se ajustan los roles UX/Design para que no computen en estimaciones por defecto.
+- Se crea y aplica la migración `0068_add_priority_custom_attribute` para sincronizar los nuevos campos en plantillas existentes y se corrige el manejo del atributo `extra` al exportar/importar plantillas.
 
-## Modificaciones realizadas
-- Actualización de `taiga/projects/fixtures/initial_project_templates.json` para establecer `"computable": false` en los roles `ux` y `design` de los dos templates iniciales y ajustar `"is_epics_activated": true` y `"is_wiki_activated": false`.
-- Migración de datos `taiga/projects/migrations/0068_update_roles_computable.py` para aplicar automáticamente el cambio en las plantillas ya almacenadas en la base de datos.
-- La propiedad `computable` controla el estado del toggle `help_role_enabled` en la interfaz de administración de roles.
+## Detalle de modificaciones
 
-## Impacto esperado
-- Los proyectos nuevos generados a partir de las plantillas incluidas dejarán de marcar los roles **UX** y **Design** como participantes de estimación por defecto.
-- Se mantiene al menos un rol computable para garantizar la funcionalidad de estimaciones.
+### Plantillas iniciales de proyectos
 
-## Verificación
-- Validación sintáctica del fixture mediante `python -m json.tool taiga/projects/fixtures/initial_project_templates.json`.
- 
-## Pasos posteriores
-- Tras modificar el fixture, ejecutar desde el backend (virtualenv activo) el comando:
+#### Roles y módulos activos
+- Se fijan los roles `ux` y `design` con `"computable": false` en ambos templates (`scrum`, `kanban`) para desactivar el toggle `help_role_enabled` por defecto y evitar que participen en la estimación.
+- Se mantiene activado el módulo de épicas en Scrum y se desactiva la wiki en las plantillas donde aplica para simplificar el onboarding según las necesidades del TFG.
 
-	```bash
-	python manage.py loaddata taiga/projects/fixtures/initial_project_templates.json
-	```
+#### Nuevos custom fields
+- **Fixture:** `taiga/projects/fixtures/initial_project_templates.json` añade cuatro atributos predeterminados:
+  - User Story → **Priority** (`dropdown` con opciones `Low`, `Medium`, `High`).
+  - User Story → **Acceptance Criteria** (`richtext`).
+  - Task → **Estimated Effort** (`number`).
+  - Task → **Actual Effort** (`number`).
+- **Migración:** `taiga/projects/migrations/0068_add_priority_custom_attribute.py` inserta estos campos en plantillas existentes respetando el orden previo y evitando duplicidades. El script recalcula el `order` en función de los atributos ya almacenados y ofrece reversión limpia en `reverse_code`.
 
-- En producción, aplicar el mismo `loaddata` tras desplegar el cambio (por ejemplo integrándolo en el playbook de despliegue o ejecutándolo manualmente en el servidor). Como alternativa, incluir la actualización en una migración de datos específica para que se ejecute automáticamente durante el despliegue.
+#### Preservar metadatos `extra`
+- **Archivo:** `taiga/projects/models.py`.
+- **Cambio clave:** Al exportar (`load_data_from_project`) y aplicar (`apply_to_project`) plantillas se incluye el campo `extra` para todos los tipos de custom attributes (epic, US, task e issue), evitando perder opciones como los valores del dropdown de prioridad.
 
-## Archivos modificados
+## Verificación realizada
+- Reaplicación dirigida de la migración para validar los datos insertados:
+
+    ```bash
+    python manage.py migrate projects 0067
+    python manage.py migrate projects 0068
+    ```
+
+- Creación de proyectos piloto a partir de los templates `scrum` y `kanban` comprobando en *Admin → Custom fields* la presencia de los cuatro atributos y que el campo **Priority** despliega las opciones configuradas.
+
+## Archivos tocados
 - `taiga/projects/fixtures/initial_project_templates.json`
+- `taiga/projects/migrations/0068_add_priority_custom_attribute.py`
+- `taiga/projects/models.py`

--- a/docs/pol_alcoverro/initial-custom.md
+++ b/docs/pol_alcoverro/initial-custom.md
@@ -1,0 +1,28 @@
+# Informe de cambios: roles UX, Design, Wiki, Epics.
+
+## Objetivo
+Ajustar la configuración inicial de los proyectos para que los roles **UX** y **Design** aparezcan con el toggle `help_role_enabled` deshabilitado al crear un nuevo proyecto. También hemos activado por defecto las épicas y desactivado la wiki en nuevos proyectos.
+
+## Modificaciones realizadas
+- Actualización de `taiga/projects/fixtures/initial_project_templates.json` para establecer `"computable": false` en los roles `ux` y `design` de los dos templates iniciales y ajustar `"is_epics_activated": true` y `"is_wiki_activated": false`.
+- Migración de datos `taiga/projects/migrations/0068_update_roles_computable.py` para aplicar automáticamente el cambio en las plantillas ya almacenadas en la base de datos.
+- La propiedad `computable` controla el estado del toggle `help_role_enabled` en la interfaz de administración de roles.
+
+## Impacto esperado
+- Los proyectos nuevos generados a partir de las plantillas incluidas dejarán de marcar los roles **UX** y **Design** como participantes de estimación por defecto.
+- Se mantiene al menos un rol computable para garantizar la funcionalidad de estimaciones.
+
+## Verificación
+- Validación sintáctica del fixture mediante `python -m json.tool taiga/projects/fixtures/initial_project_templates.json`.
+ 
+## Pasos posteriores
+- Tras modificar el fixture, ejecutar desde el backend (virtualenv activo) el comando:
+
+	```bash
+	python manage.py loaddata taiga/projects/fixtures/initial_project_templates.json
+	```
+
+- En producción, aplicar el mismo `loaddata` tras desplegar el cambio (por ejemplo integrándolo en el playbook de despliegue o ejecutándolo manualmente en el servidor). Como alternativa, incluir la actualización en una migración de datos específica para que se ejecute automáticamente durante el despliegue.
+
+## Archivos modificados
+- `taiga/projects/fixtures/initial_project_templates.json`

--- a/taiga/projects/fixtures/initial_project_templates.json
+++ b/taiga/projects/fixtures/initial_project_templates.json
@@ -10,10 +10,10 @@
         "created_date": "2014-04-22T14:48:43.596Z",
         "modified_date": "2016-08-24T16:26:40.845Z",
         "default_owner_role": "product-owner",
-        "is_epics_activated": false,
+        "is_epics_activated": true,
         "is_backlog_activated": true,
         "is_kanban_activated": false,
-        "is_wiki_activated": true,
+        "is_wiki_activated": false,
         "is_issues_activated": true,
         "videoconferences": null,
         "videoconferences_extra_data": "",
@@ -403,7 +403,7 @@
         "roles": [
             {
                 "slug": "ux",
-                "computable": true,
+                "computable": false,
                 "name": "UX",
                 "order": 10,
                 "permissions": [
@@ -444,7 +444,7 @@
             },
             {
                 "slug": "design",
-                "computable": true,
+                "computable": false,
                 "name": "Design",
                 "order": 20,
                 "permissions": [
@@ -1044,7 +1044,7 @@
         "roles": [
             {
                 "slug": "ux",
-                "computable": true,
+                "computable": false,
                 "name": "UX",
                 "order": 10,
                 "permissions": [
@@ -1085,7 +1085,7 @@
             },
             {
                 "slug": "design",
-                "computable": true,
+                "computable": false,
                 "name": "Design",
                 "order": 20,
                 "permissions": [

--- a/taiga/projects/fixtures/initial_project_templates.json
+++ b/taiga/projects/fixtures/initial_project_templates.json
@@ -635,8 +635,42 @@
             }
         ],
         "epic_custom_attributes": [],
-        "us_custom_attributes": [],
-        "task_custom_attributes": [],
+        "us_custom_attributes": [
+            {
+                "name": "Priority",
+                "description": "Sets the priority of the user story",
+                "type": "dropdown",
+                "order": 1,
+                "extra": [
+                    "Low",
+                    "Medium",
+                    "High"
+                ]
+            },
+            {
+                "name": "Acceptance Criteria",
+                "description": "Enumerates the acceptance criteria for the user story",
+                "type": "richtext",
+                "order": 2,
+                "extra": null
+            }
+        ],
+        "task_custom_attributes": [
+            {
+                "name": "Estimated Effort",
+                "description": "Estimated number of hours for completing the task",
+                "type": "number",
+                "order": 1,
+                "extra": null
+            },
+            {
+                "name": "Actual Effort",
+                "description": "Actual number of hours invested in completing the task",
+                "type": "number",
+                "order": 2,
+                "extra": null
+            }
+        ],
         "issue_custom_attributes": []
     }
 },
@@ -1276,8 +1310,42 @@
             }
         ],
         "epic_custom_attributes": [],
-        "us_custom_attributes": [],
-        "task_custom_attributes": [],
+        "us_custom_attributes": [
+            {
+                "name": "Priority",
+                "description": "Sets the priority of the user story",
+                "type": "dropdown",
+                "order": 1,
+                "extra": [
+                    "Low",
+                    "Medium",
+                    "High"
+                ]
+            },
+            {
+                "name": "Acceptance Criteria",
+                "description": "Enumerates the acceptance criteria for the user story",
+                "type": "richtext",
+                "order": 2,
+                "extra": null
+            }
+        ],
+        "task_custom_attributes": [
+            {
+                "name": "Estimated Effort",
+                "description": "Estimated number of hours for completing the task",
+                "type": "number",
+                "order": 1,
+                "extra": null
+            },
+            {
+                "name": "Actual Effort",
+                "description": "Actual number of hours invested in completing the task",
+                "type": "number",
+                "order": 2,
+                "extra": null
+            }
+        ],
         "issue_custom_attributes": []
     }
 }

--- a/taiga/projects/migrations/0068_add_priority_custom_attribute.py
+++ b/taiga/projects/migrations/0068_add_priority_custom_attribute.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2021-present Kaleidos INC
+
+from copy import deepcopy
+
+from django.db import migrations
+
+
+US_CUSTOM_ATTRIBUTES = [
+    {
+        "name": "Priority",
+        "description": "Sets the priority of the user story",
+        "type": "dropdown",
+        "order": 1,
+        "extra": ["Low", "Medium", "High"],
+    },
+    {
+        "name": "Acceptance Criteria",
+        "description": "Enumerates the acceptance criteria for the user story",
+        "type": "richtext",
+        "order": 2,
+        "extra": None,
+    },
+]
+
+
+TASK_CUSTOM_ATTRIBUTES = [
+    {
+        "name": "Estimated Effort",
+        "description": "Estimated number of hours for completing the task",
+        "type": "number",
+        "order": 1,
+        "extra": None,
+    },
+    {
+        "name": "Actual Effort",
+        "description": "Actual number of hours invested in completing the task",
+        "type": "number",
+        "order": 2,
+        "extra": None,
+    },
+]
+
+
+def add_custom_attributes(apps, schema_editor):
+    ProjectTemplate = apps.get_model("projects", "ProjectTemplate")
+
+    for template in ProjectTemplate.objects.all():
+        us_attrs = list(template.us_custom_attributes or [])
+        task_attrs = list(template.task_custom_attributes or [])
+
+        next_us_order = max((attr.get("order", 0) for attr in us_attrs), default=0)
+        changed = False
+
+        for definition in US_CUSTOM_ATTRIBUTES:
+            if any(attr.get("name") == definition["name"] for attr in us_attrs):
+                continue
+
+            next_us_order += 1
+            attr_copy = deepcopy(definition)
+            attr_copy["order"] = next_us_order
+            us_attrs.append(attr_copy)
+            changed = True
+
+        next_task_order = max((attr.get("order", 0) for attr in task_attrs), default=0)
+
+        for definition in TASK_CUSTOM_ATTRIBUTES:
+            if any(attr.get("name") == definition["name"] for attr in task_attrs):
+                continue
+
+            next_task_order += 1
+            attr_copy = deepcopy(definition)
+            attr_copy["order"] = next_task_order
+            task_attrs.append(attr_copy)
+            changed = True
+
+        if changed:
+            template.us_custom_attributes = us_attrs
+            template.task_custom_attributes = task_attrs
+            template.save(update_fields=["us_custom_attributes", "task_custom_attributes", "modified_date"])
+
+
+def remove_custom_attributes(apps, schema_editor):
+    ProjectTemplate = apps.get_model("projects", "ProjectTemplate")
+
+    us_names = {attr["name"] for attr in US_CUSTOM_ATTRIBUTES}
+    task_names = {attr["name"] for attr in TASK_CUSTOM_ATTRIBUTES}
+
+    for template in ProjectTemplate.objects.all():
+        us_attrs = list(template.us_custom_attributes or [])
+        task_attrs = list(template.task_custom_attributes or [])
+
+        filtered_us = [attr for attr in us_attrs if attr.get("name") not in us_names]
+        filtered_task = [attr for attr in task_attrs if attr.get("name") not in task_names]
+
+        if filtered_us == us_attrs and filtered_task == task_attrs:
+            continue
+
+        template.us_custom_attributes = filtered_us
+        template.task_custom_attributes = filtered_task
+        template.save(update_fields=["us_custom_attributes", "task_custom_attributes", "modified_date"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("projects", "0067_auto_20201230_1237"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_custom_attributes, remove_custom_attributes),
+    ]

--- a/taiga/projects/models.py
+++ b/taiga/projects/models.py
@@ -1195,7 +1195,8 @@ class ProjectTemplate(TaggedMixin, TagsColorsMixin, models.Model):
                 "name": ca.name,
                 "description": ca.description,
                 "type": ca.type,
-                "order": ca.order
+                "order": ca.order,
+                "extra": ca.extra
             })
 
         self.us_custom_attributes = []
@@ -1204,7 +1205,8 @@ class ProjectTemplate(TaggedMixin, TagsColorsMixin, models.Model):
                 "name": ca.name,
                 "description": ca.description,
                 "type": ca.type,
-                "order": ca.order
+                "order": ca.order,
+                "extra": ca.extra
             })
 
         self.task_custom_attributes = []
@@ -1213,7 +1215,8 @@ class ProjectTemplate(TaggedMixin, TagsColorsMixin, models.Model):
                 "name": ca.name,
                 "description": ca.description,
                 "type": ca.type,
-                "order": ca.order
+                "order": ca.order,
+                "extra": ca.extra
             })
 
         self.issue_custom_attributes = []
@@ -1222,7 +1225,8 @@ class ProjectTemplate(TaggedMixin, TagsColorsMixin, models.Model):
                 "name": ca.name,
                 "description": ca.description,
                 "type": ca.type,
-                "order": ca.order
+                "order": ca.order,
+                "extra": ca.extra
             })
 
         try:
@@ -1398,6 +1402,7 @@ class ProjectTemplate(TaggedMixin, TagsColorsMixin, models.Model):
                 description=ca["description"],
                 type=ca["type"],
                 order=ca["order"],
+                extra=ca.get("extra"),
                 project=project
             )
 
@@ -1407,6 +1412,7 @@ class ProjectTemplate(TaggedMixin, TagsColorsMixin, models.Model):
                 description=ca["description"],
                 type=ca["type"],
                 order=ca["order"],
+                extra=ca.get("extra"),
                 project=project
             )
 
@@ -1416,6 +1422,7 @@ class ProjectTemplate(TaggedMixin, TagsColorsMixin, models.Model):
                 description=ca["description"],
                 type=ca["type"],
                 order=ca["order"],
+                extra=ca.get("extra"),
                 project=project
             )
 
@@ -1425,6 +1432,7 @@ class ProjectTemplate(TaggedMixin, TagsColorsMixin, models.Model):
                 description=ca["description"],
                 type=ca["type"],
                 order=ca["order"],
+                extra=ca.get("extra"),
                 project=project
             )
 


### PR DESCRIPTION
This pull request enriches the initial Taiga project templates by introducing new custom fields, adjusting UX/Design role behavior, and ensuring proper handling of custom attribute metadata during template import/export. It also includes a migration to synchronize these changes across existing templates, preventing data loss and improving onboarding for new projects.

**Template customization and new fields:**

* Added four default custom attributes to project templates: for User Stories—`Priority` (dropdown: Low/Medium/High) and `Acceptance Criteria` (richtext); for Tasks—`Estimated Effort` and `Actual Effort` (both numeric). These are included in both the fixture (`initial_project_templates.json`) and a new migration to update existing templates. [[1]](diffhunk://#diff-a2eafd199139c754a2d9916be097243b6e017a0a5c700c8f48041eaf65ab63b9L638-R673) [[2]](diffhunk://#diff-a2eafd199139c754a2d9916be097243b6e017a0a5c700c8f48041eaf65ab63b9L1279-R1348) [[3]](diffhunk://#diff-67c2cf8bd8477d033b84b32f3bba8d99cfd8142c9c3a5be05b5a95100f6c71f7R1-R116)
* The new migration (`0068_add_priority_custom_attribute.py`) inserts these fields in the correct order, avoids duplicates, and supports clean rollback.

**Role and module adjustments:**

* Set `computable: false` for `ux` and `design` roles in both Scrum and Kanban templates, so they do not participate in effort estimation by default. [[1]](diffhunk://#diff-a2eafd199139c754a2d9916be097243b6e017a0a5c700c8f48041eaf65ab63b9L406-R406) [[2]](diffhunk://#diff-a2eafd199139c754a2d9916be097243b6e017a0a5c700c8f48041eaf65ab63b9L447-R447) [[3]](diffhunk://#diff-a2eafd199139c754a2d9916be097243b6e017a0a5c700c8f48041eaf65ab63b9L1047-R1081) [[4]](diffhunk://#diff-a2eafd199139c754a2d9916be097243b6e017a0a5c700c8f48041eaf65ab63b9L1088-R1122)
* Enabled epics and disabled wiki modules in Scrum templates to better fit onboarding needs.

**Custom attribute metadata preservation:**

* Updated `load_data_from_project` and `apply_to_project` methods in `models.py` to include the `extra` field for all custom attribute types, ensuring dropdown options and similar metadata are retained during template export/import. [[1]](diffhunk://#diff-be8e70c40d695edd532ddcd4d084b6eed78ce31853c01652bf1e42a5fcd7b0b1L1198-R1199) [[2]](diffhunk://#diff-be8e70c40d695edd532ddcd4d084b6eed78ce31853c01652bf1e42a5fcd7b0b1L1207-R1209) [[3]](diffhunk://#diff-be8e70c40d695edd532ddcd4d084b6eed78ce31853c01652bf1e42a5fcd7b0b1L1216-R1219) [[4]](diffhunk://#diff-be8e70c40d695edd532ddcd4d084b6eed78ce31853c01652bf1e42a5fcd7b0b1L1225-R1229) [[5]](diffhunk://#diff-be8e70c40d695edd532ddcd4d084b6eed78ce31853c01652bf1e42a5fcd7b0b1R1405) [[6]](diffhunk://#diff-be8e70c40d695edd532ddcd4d084b6eed78ce31853c01652bf1e42a5fcd7b0b1R1415) [[7]](diffhunk://#diff-be8e70c40d695edd532ddcd4d084b6eed78ce31853c01652bf1e42a5fcd7b0b1R1425) [[8]](diffhunk://#diff-be8e70c40d695edd532ddcd4d084b6eed78ce31853c01652bf1e42a5fcd7b0b1R1435)

**Documentation:**

* Added a detailed executive summary and technical breakdown of these changes in `docs/pol_alcoverro/initial-custom.md`.