### PR TITLE
Feat/2/login google

### DIFF
--- a/docs/pol_alcoverro/LoginGoogle.md
+++ b/docs/pol_alcoverro/LoginGoogle.md
@@ -1,0 +1,67 @@
+# Google SSO Backend Integration
+
+## Overview
+- Adds a `google` auth plugin to `/api/v1/auth` that accepts Google Identity Services ID tokens.
+- Tokens are verified with `google-auth==2.29.0`, the official library maintained by Google (Apache 2.0, compatible with MPL/AGPL obligations).
+- Only emails from `@upc.edu` and `@estudiantat.upc.edu` are allowed by default; domains can be tuned via configuration while the backend enforces the restriction server-side.
+- Existing users are matched by email (case-insensitive). New accounts are auto-provisioned with verified-email status unless disabled.
+
+## Cambios aplicados (taiga-back)
+- `taiga-back/settings/common.py`: se anadio el bloque `GOOGLE_AUTH` con nuevas variables de entorno (`GOOGLE_AUTH_CLIENT_IDS`, `GOOGLE_AUTH_ALLOWED_DOMAINS`, `GOOGLE_AUTH_AUTO_CREATE`, `GOOGLE_AUTH_ENABLED`) y valores por defecto pensados para desarrollo UPC.
+- `taiga-back/requirements.in` y `taiga-back/requirements.txt`: se incluyo el paquete `google-auth` y dependencias derivadas para validar tokens de Google desde Django.
+- `taiga-back/taiga/auth/services.py`: el cargador de plugins comprueba `settings.GOOGLE_AUTH['ENABLED']` y registra dinamicamente el proveedor Google; ante configuraciones invalidas devuelve un `400` controlado.
+- `taiga-back/taiga/auth/providers/google.py`: nuevo manejador `login_with_google` que valida el token, comprueba dominio permitido, crea usuarios cuando `AUTO_CREATE_USERS` esta activo y responde con el mismo payload que el login clasico.
+- Traducciones: se introdujeron mensajes traducibles especificos en `taiga/auth/providers/google.py` para exponer errores de configuracion o dominio de manera controlada.
+- `taiga-back/taiga/auth/services.py`: Pol Alcoverro comentó el login y registro clásicos (`login`, `public_register`, `private_register_for_new_user`) para que ahora respondan con un `400` controlado y dejó el código original comentado para referencia.
+
+## Configuration
+Set the following environment variables (e.g. in `settings/local.py` or process env):
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `GOOGLE_AUTH_CLIENT_IDS` | `286907234950-enq7c1j4085fbj662otfptqqo24hk93u.apps.googleusercontent.com` | Comma-separated list of OAuth 2.0 client IDs issued by Google (typically the web client ID). Override in production with your own ID(s). |
+| `GOOGLE_AUTH_ENABLED` | auto (`true` when client IDs provided) | Explicitly enable/disable the plugin. |
+| `GOOGLE_AUTH_ALLOWED_DOMAINS` | `upc.edu,estudiantat.upc.edu` | Comma-separated list of domains accepted for login; compared against both the email domain and the `hd` claim. |
+| `GOOGLE_AUTH_AUTO_CREATE` | `true` | When `true`, a Taiga account is created automatically for first-time allowed domain users; when `false`, only pre-existing users can log in. |
+
+Behavioural notes:
+- Users created through Google SSO receive an unusable password, `verified_email=True`, and inherit default limits/terms acceptance flags. Rename/update their profile as usual via the UI.
+- When `invitation_token` is sent alongside the login payload, the normal invitation acceptance flow still runs.
+- If configuration is invalid (missing dependency, missing client IDs), the API returns `400` with a friendly error instead of exposing internal tracebacks.
+- The sample development client ID ships in `settings/common.py`; set the environment variable in every deployed environment to replace it with your own credential(s).
+
+## Request Payload
+The frontend posts to `/api/v1/auth` with `type=google` and the Google credential:
+
+```json
+{
+  "type": "google",
+  "credential": "<ID_TOKEN>",
+  "client_id": "<matching Google client ID>",
+  "invitation_token": "<optional invitation token>"
+}
+```
+
+The response mirrors Taiga's standard auth payload (user information, `auth_token`, `refresh`).
+
+## Dependencies and Licensing
+- `google-auth==2.29.0` plus its transitive requirements (`cachetools`, `rsa`, `pyasn1`, `pyasn1-modules`) are pinned in `requirements.txt`.
+- `google-auth` is Apache 2.0 licensed; Apache 2.0 is compatible with MPL 2.0 / AGPL compliance duties already observed in Taiga. Keep NOTICE files intact if you redistribute binaries.
+- Google Identity Services usage must comply with Google's OAuth Terms of Service; no user data beyond the ID token is stored server-side.
+
+## Logging & Error Surfaces
+- Invalid tokens, audience mismatches, or non-permitted domains raise `400 Bad Request` with translated messages (consumed by the frontend notifier).
+- Disabled or system users produce a controlled `400` with an explicit explanation.
+- Token verification failures are logged at warning level for traceability but avoid leaking token contents.
+
+## Operational Checklist
+1. Obtain the OAuth 2.0 Web client ID from [Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+2. Configure redirect URIs as needed for GIS One Tap/button usage; no backend redirect endpoints are required because we exchange ID tokens only.
+3. Override `GOOGLE_AUTH_CLIENT_IDS` (and optionally the other knobs) via environment variables or your deployment tooling, then restart the backend.
+4. Install/update dependencies: `pip install -r requirements.txt`.
+5. Optionally add integration tests exercising `/api/v1/auth` with mocked Google responses (the helper accepts patching `google.oauth2.id_token.verify_oauth2_token`).
+
+## Residual Considerations
+- Rate limiting relies on existing login throttles; heavy misuse could still surface, so monitor failed login metrics.
+- If additional domains must be admitted later, update both `GOOGLE_AUTH_ALLOWED_DOMAINS` and the frontend hint text (the UI reads the list dynamically).
+- Revoking auto-provisioning requires `GOOGLE_AUTH_AUTO_CREATE=false` and ensuring target users are pre-created by admins.

--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ django-sites==0.11
 django-sr==0.0.4
 djmail==2.0.0
 easy-thumbnails==2.8.5
+google-auth==2.29.0
 gunicorn==20.1.0
 netaddr<0.9
 premailer==3.0.1

--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ django-sites==0.11
 django-sr==0.0.4
 djmail==2.0.0
 easy-thumbnails==2.8.5
+# Pol Alcoverro: dependencia para validar tokens Google.
 google-auth==2.29.0
 gunicorn==20.1.0
 netaddr<0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,6 +91,7 @@ docopt==0.6.2
     # via psd-tools
 easy-thumbnails==2.8.5
     # via -r requirements.in
+# Pol Alcoverro: dependencia para validar tokens Google.
 google-auth==2.29.0
     # via -r requirements.in
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,8 @@ cairocffi==1.4.0
     # via cairosvg
 cairosvg==2.6.0
     # via -r requirements.in
+cachetools==5.3.1
+    # via google-auth
 celery==5.2.7
     # via -r requirements.in
 certifi==2022.12.7
@@ -88,6 +90,8 @@ djmail==2.0.0
 docopt==0.6.2
     # via psd-tools
 easy-thumbnails==2.8.5
+    # via -r requirements.in
+google-auth==2.29.0
     # via -r requirements.in
 gunicorn==20.1.0
     # via -r requirements.in
@@ -155,6 +159,14 @@ pygments==2.14.0
     # via -r requirements.in
 pyjwt==2.6.0
     # via oauthlib
+pyasn1==0.5.1
+    # via
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.3.0
+    # via
+    #   google-auth
+    #   rsa
 pymdown-extensions==9.9.2
     # via -r requirements.in
 python-dateutil==2.7.5
@@ -186,6 +198,8 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements.in
     #   asana
+rsa==4.9
+    # via google-auth
 rudder-sdk-python==1.0.0b1
     # via -r requirements.in
 sampledata==0.3.7

--- a/settings/common.py
+++ b/settings/common.py
@@ -72,6 +72,7 @@ GOOGLE_AUTH_CLIENT_IDS = env_to_list(
 GOOGLE_AUTH_AUTO_CREATE_USERS = env_to_bool("GOOGLE_AUTH_AUTO_CREATE", default=True)
 _google_auth_enabled_flag = env_to_bool("GOOGLE_AUTH_ENABLED", default=bool(GOOGLE_AUTH_CLIENT_IDS))
 
+# Pol Alcoverro: configuración server-side para habilitar el login con Google.
 GOOGLE_AUTH = {
     "ENABLED": bool(GOOGLE_AUTH_CLIENT_IDS) and _google_auth_enabled_flag,
     "CLIENT_IDS": GOOGLE_AUTH_CLIENT_IDS,

--- a/settings/common.py
+++ b/settings/common.py
@@ -11,6 +11,22 @@ import sys
 from datetime import timedelta
 
 
+def env_to_bool(name, default=False):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in ("1", "true", "yes", "on")
+
+
+def env_to_list(name, default=None):
+    value = os.environ.get(name)
+    if value is None:
+        if default is None:
+            return []
+        return [item.strip() for item in default if item and item.strip()]
+    return [item.strip() for item in value.split(',') if item.strip()]
+
+
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 APPEND_SLASH = False
@@ -27,7 +43,7 @@ DATABASES = {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": "taiga",
         "USER": "taiga",
-        "PASSWORD": "taiga",
+        "PASSWORD": "taigaupc",
         "HOST": "127.0.0.1"
     }
 }
@@ -43,6 +59,25 @@ CACHES = {
 }
 
 INSTANCE_TYPE = "SRC"
+
+
+GOOGLE_AUTH_ALLOWED_DOMAINS = [domain.lower() for domain in env_to_list(
+    "GOOGLE_AUTH_ALLOWED_DOMAINS",
+    ["upc.edu", "estudiantat.upc.edu"],
+)]
+GOOGLE_AUTH_CLIENT_IDS = env_to_list(
+    "GOOGLE_AUTH_CLIENT_IDS",
+    ["286907234950-enq7c1j4085fbj662otfptqqo24hk93u.apps.googleusercontent.com"],
+)
+GOOGLE_AUTH_AUTO_CREATE_USERS = env_to_bool("GOOGLE_AUTH_AUTO_CREATE", default=True)
+_google_auth_enabled_flag = env_to_bool("GOOGLE_AUTH_ENABLED", default=bool(GOOGLE_AUTH_CLIENT_IDS))
+
+GOOGLE_AUTH = {
+    "ENABLED": bool(GOOGLE_AUTH_CLIENT_IDS) and _google_auth_enabled_flag,
+    "CLIENT_IDS": GOOGLE_AUTH_CLIENT_IDS,
+    "ALLOWED_DOMAINS": GOOGLE_AUTH_ALLOWED_DOMAINS,
+    "AUTO_CREATE_USERS": GOOGLE_AUTH_AUTO_CREATE_USERS,
+}
 
 # CELERY
 CELERY_ENABLED = False

--- a/taiga/auth/providers/google.py
+++ b/taiga/auth/providers/google.py
@@ -146,6 +146,7 @@ def _create_user_from_payload(email: str, payload: dict):
     return user
 
 
+# Pol Alcoverro: punto de entrada del login mediante Google Identity Services.
 def login_with_google(request):
     raw_token = request.DATA.get("credential") or request.DATA.get("id_token")
     client_hint = request.DATA.get("client_id")

--- a/taiga/auth/providers/google.py
+++ b/taiga/auth/providers/google.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2021-present Kaleidos INC
+
+import logging
+import re
+from typing import Iterable, Optional
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ImproperlyConfigured
+from django.db import transaction as db_transaction
+from django.utils.translation import gettext_lazy as _
+
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token
+
+from taiga.auth.services import make_auth_response_data, register_auth_plugin
+from taiga.base import exceptions as exc
+
+
+logger = logging.getLogger(__name__)
+
+CONFIG = getattr(settings, "GOOGLE_AUTH", {})
+CLIENT_IDS: Iterable[str] = tuple(CONFIG.get("CLIENT_IDS", []))
+ALLOWED_DOMAINS = {domain.lower() for domain in CONFIG.get("ALLOWED_DOMAINS", []) if domain}
+AUTO_CREATE_USERS = bool(CONFIG.get("AUTO_CREATE_USERS", True))
+
+if not CLIENT_IDS:
+    raise ImproperlyConfigured("Google auth plugin requires at least one client id")
+
+_GOOGLE_REQUEST = google_requests.Request()
+_USERNAME_SANITIZER = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def _normalise_username(value: str) -> str:
+    cleaned = _USERNAME_SANITIZER.sub("-", (value or "").lower()).strip(".-")
+    cleaned = re.sub(r"-+", "-", cleaned)
+    return cleaned or "user"
+
+
+def _build_unique_username(email_local_part: str) -> str:
+    base = _normalise_username(email_local_part)
+    user_model = get_user_model()
+
+    candidate = base
+    suffix = 1
+    while user_model.objects.filter(username=candidate).exists():
+        candidate = f"{base}-{suffix}"
+        suffix += 1
+
+    return candidate
+
+
+def _extract_full_name(payload: dict) -> str:
+    full_name = (payload.get("name") or "").strip()
+    if full_name:
+        return full_name
+
+    given = (payload.get("given_name") or "").strip()
+    family = (payload.get("family_name") or "").strip()
+    full_name = " ".join(part for part in (given, family) if part)
+    return full_name or ""
+
+
+def _verify_credential(raw_token: str, client_hint: Optional[str]) -> dict:
+    if not raw_token:
+        raise exc.BadRequest(_("Missing Google credential."))
+
+    audiences = CLIENT_IDS
+    if client_hint and client_hint in CLIENT_IDS:
+        audiences = (client_hint,)
+
+    last_error = None
+    for audience in audiences:
+        try:
+            return id_token.verify_oauth2_token(raw_token, _GOOGLE_REQUEST, audience=audience)
+        except ValueError as err:  # pragma: no cover - google-auth raises ValueError
+            last_error = err
+
+    logger.warning("Google credential verification failed: %s", last_error)
+    raise exc.BadRequest(_("Invalid Google credential.")) from last_error
+
+
+def _ensure_domain_allowed(email: str, hosted_domain: Optional[str]):
+    email_domain = email.split("@")[-1].lower()
+    if ALLOWED_DOMAINS and email_domain not in ALLOWED_DOMAINS:
+        raise exc.BadRequest(_("Your Google account is not allowed to sign in."))
+
+    if hosted_domain:
+        hosted_domain = hosted_domain.lower()
+        if ALLOWED_DOMAINS and hosted_domain not in ALLOWED_DOMAINS:
+            raise exc.BadRequest(_("Your Google Workspace domain is not allowed."))
+
+
+def _get_or_create_user(email: str, payload: dict):
+    user_model = get_user_model()
+
+    try:
+        user = user_model.objects.get(email__iexact=email)
+    except user_model.DoesNotExist:
+        if not AUTO_CREATE_USERS:
+            raise exc.BadRequest(_("This Google account is not associated with a Taiga user."))
+        user = _create_user_from_payload(email, payload)
+    else:
+        if not user.is_active or user.is_system:
+            raise exc.BadRequest(_("This user account is disabled."))
+
+        update_fields = []
+        if not user.verified_email:
+            user.verified_email = True
+            update_fields.append("verified_email")
+
+        new_full_name = _extract_full_name(payload)
+        if new_full_name and not user.full_name:
+            user.full_name = new_full_name
+            update_fields.append("full_name")
+
+        if update_fields:
+            user.save(update_fields=update_fields)
+
+    return user
+
+
+@db_transaction.atomic
+def _create_user_from_payload(email: str, payload: dict):
+    user_model = get_user_model()
+    local_part = email.split("@")[0]
+    username = _build_unique_username(local_part)
+    full_name = _extract_full_name(payload)
+
+    user = user_model(
+        username=username,
+        email=email,
+        full_name=full_name,
+        verified_email=True,
+        accepted_terms=True,
+        read_new_terms=True,
+        new_email=None,
+    )
+    user.set_unusable_password()
+    user.save()
+    return user
+
+
+def login_with_google(request):
+    raw_token = request.DATA.get("credential") or request.DATA.get("id_token")
+    client_hint = request.DATA.get("client_id")
+
+    payload = _verify_credential(raw_token, client_hint)
+
+    if payload.get("aud") not in CLIENT_IDS:
+        logger.warning("Rejected Google credential with unexpected audience: %s", payload.get("aud"))
+        raise exc.BadRequest(_("Invalid Google credential."))
+
+    if payload.get("iss") not in {"accounts.google.com", "https://accounts.google.com"}:
+        logger.warning("Rejected Google credential with invalid issuer: %s", payload.get("iss"))
+        raise exc.BadRequest(_("Invalid Google credential."))
+
+    if payload.get("email_verified") is not True:
+        raise exc.BadRequest(_("Google has not verified this email address."))
+
+    email = payload.get("email")
+    if not email:
+        raise exc.BadRequest(_("Google did not return an email address."))
+
+    _ensure_domain_allowed(email, payload.get("hd"))
+
+    user = _get_or_create_user(email.lower(), payload)
+    return make_auth_response_data(user)
+
+
+register_auth_plugin("google", login_with_google)

--- a/taiga/auth/services.py
+++ b/taiga/auth/services.py
@@ -54,6 +54,7 @@ def _ensure_auth_plugins_loaded():
     try:
         config = getattr(settings, "GOOGLE_AUTH", {})
         if config.get("ENABLED"):
+            # Pol Alcoverro: registro del proveedor de login Google.
             from .providers import google  # noqa: F401
     except (ImportError, ImproperlyConfigured) as exc_import:
         logger.exception("Google authentication plugin enabled but misconfigured")

--- a/taiga/auth/services.py
+++ b/taiga/auth/services.py
@@ -87,16 +87,19 @@ def make_auth_response_data(user):
 
 
 def login(username: str, password: str):
-    try:
-        user = get_and_validate_user(username=username, password=password)
-    except exc.WrongArguments:
-        raise AuthenticationFailed(
-            _('No active account found with the given credentials'),
-            'invalid_credentials',
-        )
+    # Pol Alcoverro: comentado codigo por deshabilitar el login clasico en favor de Google SSO.
+    raise exc.BadRequest(_('Classic login is disabled.'))
 
-    # Generate data
-    return make_auth_response_data(user)
+    # Pol Alcoverro: comentado codigo por conservar el flujo original sin ejecutarlo.
+    # try:
+    #     user = get_and_validate_user(username=username, password=password)
+    # except exc.WrongArguments:
+    #     raise AuthenticationFailed(
+    #         _('No active account found with the given credentials'),
+    #         'invalid_credentials',
+    #     )
+    #
+    # return make_auth_response_data(user)
 
 
 def refresh_token(refresh_token: str):
@@ -174,27 +177,31 @@ def public_register(username:str, password:str, email:str, full_name:str):
     :returns: User
     """
 
-    is_registered, reason = is_user_already_registered(username=username, email=email)
-    if is_registered:
-        raise exc.WrongArguments(reason)
+    # Pol Alcoverro: comentado codigo por deshabilitar el registro clasico en favor de Google SSO.
+    raise exc.BadRequest(_('Public registration is disabled.'))
 
-    user_model = get_user_model()
-    user = user_model(username=username,
-                      email=email,
-                      email_token=str(uuid.uuid4()),
-                      new_email=email,
-                      verified_email=False,
-                      full_name=full_name,
-                      read_new_terms=True)
-    user.set_password(password)
-    try:
-        user.save()
-    except IntegrityError:
-        raise exc.WrongArguments(_("User is already registered."))
-
-    send_register_email(user)
-    user_registered_signal.send(sender=user.__class__, user=user)
-    return user
+    # Pol Alcoverro: comentado codigo por conservar el flujo original sin ejecutarlo.
+    # is_registered, reason = is_user_already_registered(username=username, email=email)
+    # if is_registered:
+    #     raise exc.WrongArguments(reason)
+    #
+    # user_model = get_user_model()
+    # user = user_model(username=username,
+    #                   email=email,
+    #                   email_token=str(uuid.uuid4()),
+    #                   new_email=email,
+    #                   verified_email=False,
+    #                   full_name=full_name,
+    #                   read_new_terms=True)
+    # user.set_password(password)
+    # try:
+    #     user.save()
+    # except IntegrityError:
+    #     raise exc.WrongArguments(_('User is already registered.'))
+    #
+    # send_register_email(user)
+    # user_registered_signal.send(sender=user.__class__, user=user)
+    # return user
 
 
 @tx.atomic
@@ -204,29 +211,33 @@ def private_register_for_new_user(token:str, username:str, email:str,
     Given a inviation token, try register new user matching
     the invitation token.
     """
-    is_registered, reason = is_user_already_registered(username=username, email=email)
-    if is_registered:
-        raise exc.WrongArguments(reason)
+    # Pol Alcoverro: comentado codigo por deshabilitar el registro clasico vinculado a invitaciones.
+    raise exc.BadRequest(_('Public registration is disabled.'))
 
-    user_model = get_user_model()
-    user = user_model(username=username,
-                      email=email,
-                      full_name=full_name,
-                      email_token=str(uuid.uuid4()),
-                      new_email=email,
-                      verified_email=False,
-                      read_new_terms=True)
-
-    user.set_password(password)
-    try:
-        user.save()
-    except IntegrityError:
-        raise exc.WrongArguments(_("Error while creating new user."))
-
-    membership = get_membership_by_token(token)
-    membership.user = user
-    membership.save(update_fields=["user"])
-    send_register_email(user)
-    user_registered_signal.send(sender=user.__class__, user=user)
-
-    return user
+    # Pol Alcoverro: comentado codigo por conservar el flujo original sin ejecutarlo.
+    # is_registered, reason = is_user_already_registered(username=username, email=email)
+    # if is_registered:
+    #     raise exc.WrongArguments(reason)
+    #
+    # user_model = get_user_model()
+    # user = user_model(username=username,
+    #                   email=email,
+    #                   full_name=full_name,
+    #                   email_token=str(uuid.uuid4()),
+    #                   new_email=email,
+    #                   verified_email=False,
+    #                   read_new_terms=True)
+    #
+    # user.set_password(password)
+    # try:
+    #     user.save()
+    # except IntegrityError:
+    #     raise exc.WrongArguments(_('Error while creating new user.'))
+    #
+    # membership = get_membership_by_token(token)
+    # membership.user = user
+    # membership.save(update_fields=["user"])
+    # send_register_email(user)
+    # user_registered_signal.send(sender=user.__class__, user=user)
+    #
+    # return user

--- a/tests/config.py
+++ b/tests/config.py
@@ -53,7 +53,8 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'taiga',
         'USER': 'taiga',
-        'PASSWORD': 'taiga',
+    # Local TFG environment uses taigaupc as default password.
+    'PASSWORD': 'taigaupc',
         'HOST': 'localhost',
         'PORT': '5432',
     }

--- a/tests/integration/resources_permissions/test_auth_resources.py
+++ b/tests/integration/resources_permissions/test_auth_resources.py
@@ -5,6 +5,8 @@
 #
 # Copyright (c) 2021-present Kaleidos INC
 
+# Pol Alcoverro
+
 from django.urls import reverse
 
 from taiga.base.utils import json
@@ -13,7 +15,10 @@ from tests import factories as f
 from tests.utils import disconnect_signals, reconnect_signals
 
 import pytest
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.skip(reason="Pol Alcoverro: Classic login and registration resources disabled in Google SSO build."),
+]
 
 
 def setup_module(module):

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -5,6 +5,8 @@
 #
 # Copyright (c) 2021-present Kaleidos INC
 
+# Pol Alcoverro
+
 import pytest
 
 from django.urls import reverse
@@ -12,7 +14,10 @@ from django.core import mail
 
 from .. import factories
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.skip(reason="Pol Alcoverro: Classic login and registration disabled in Google SSO build."),
+]
 
 
 @pytest.fixture
@@ -492,4 +497,3 @@ def test_login_fail_throttling(client, settings):
     assert response.status_code == 429, response.data
 
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["login-fail"] = None
-

--- a/tests/unit/auth/test_google_provider.py
+++ b/tests/unit/auth/test_google_provider.py
@@ -1,0 +1,229 @@
+# Pol Alcoverro
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2021-present Kaleidos INC
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from django.contrib.auth import get_user_model
+
+from taiga.base import exceptions as exc
+
+from tests import factories as f
+
+
+class DummyRequest(SimpleNamespace):
+    def __init__(self, data):
+        super().__init__(DATA=data)
+
+
+@pytest.fixture
+def reload_google(settings):
+    from taiga.auth import services as auth_services
+
+    original_plugins = dict(auth_services.auth_plugins)
+
+    def _reload(extra_settings=None):
+        config = {
+            "CLIENT_IDS": ["test-client"],
+            "ALLOWED_DOMAINS": ["upc.edu", "estudiantat.upc.edu"],
+            "AUTO_CREATE_USERS": True,
+            "ENABLED": True,
+        }
+        if extra_settings:
+            config.update(extra_settings)
+        settings.GOOGLE_AUTH = config
+
+        import taiga.auth.providers.google as google_module
+
+        module = importlib.reload(google_module)
+        return module
+
+    yield _reload
+
+    auth_services.auth_plugins.clear()
+    auth_services.auth_plugins.update(original_plugins)
+
+
+@pytest.mark.django_db
+def test_login_creates_new_user(monkeypatch, reload_google):
+    google_module = reload_google()
+
+    captured_user = {}
+
+    def fake_verify(raw_token, request, audience):
+        assert raw_token == "good-token"
+        assert audience == "test-client"
+        return {
+            "aud": "test-client",
+            "iss": "accounts.google.com",
+            "email": "john@upc.edu",
+            "email_verified": True,
+            "name": "John Doe",
+        }
+
+    def fake_auth_response(user):
+        captured_user["instance"] = user
+        return {"auth_token": "dummy", "refresh": "dummy"}
+
+    monkeypatch.setattr(google_module.id_token, "verify_oauth2_token", fake_verify)
+    monkeypatch.setattr(google_module, "make_auth_response_data", fake_auth_response)
+
+    request = DummyRequest({"credential": "good-token", "client_id": "test-client"})
+
+    response = google_module.login_with_google(request)
+
+    user_model = get_user_model()
+    user = user_model.objects.get(email="john@upc.edu")
+
+    assert response == {"auth_token": "dummy", "refresh": "dummy"}
+    assert captured_user["instance"] == user
+    assert user.full_name == "John Doe"
+    assert user.verified_email is True
+    assert user.has_usable_password() is False
+
+
+@pytest.mark.django_db
+def test_login_updates_existing_user(monkeypatch, reload_google):
+    google_module = reload_google()
+
+    user = f.UserFactory(
+        username="existing",
+        email="existing@upc.edu",
+        verified_email=False,
+        full_name="",
+        is_system=False,
+    )
+
+    def fake_verify(raw_token, request, audience):
+        return {
+            "aud": "test-client",
+            "iss": "https://accounts.google.com",
+            "email": "existing@upc.edu",
+            "email_verified": True,
+            "name": "Existing User",
+        }
+
+    def fake_auth_response(auth_user):
+        assert auth_user == user
+        return {"auth_token": "dummy", "refresh": "dummy"}
+
+    monkeypatch.setattr(google_module.id_token, "verify_oauth2_token", fake_verify)
+    monkeypatch.setattr(google_module, "make_auth_response_data", fake_auth_response)
+
+    request = DummyRequest({"credential": "valid", "client_id": "test-client"})
+
+    result = google_module.login_with_google(request)
+
+    user.refresh_from_db()
+    assert result["auth_token"] == "dummy"
+    assert user.verified_email is True
+    assert user.full_name == "Existing User"
+
+
+@pytest.mark.django_db
+def test_login_rejects_disallowed_domain(monkeypatch, reload_google):
+    google_module = reload_google()
+
+    def fake_verify(raw_token, request, audience):
+        return {
+            "aud": "test-client",
+            "iss": "accounts.google.com",
+            "email": "intruder@gmail.com",
+            "email_verified": True,
+        }
+
+    monkeypatch.setattr(google_module.id_token, "verify_oauth2_token", fake_verify)
+
+    request = DummyRequest({"credential": "token", "client_id": "test-client"})
+
+    with pytest.raises(exc.BadRequest) as error_info:
+        google_module.login_with_google(request)
+
+    assert "not allowed" in str(error_info.value.detail)
+
+
+@pytest.mark.django_db
+def test_login_rejects_when_auto_create_disabled(monkeypatch, reload_google):
+    google_module = reload_google({"AUTO_CREATE_USERS": False})
+    assert google_module.AUTO_CREATE_USERS is False
+
+    def fake_verify(raw_token, request, audience):
+        return {
+            "aud": "test-client",
+            "iss": "accounts.google.com",
+            "email": "new@upc.edu",
+            "email_verified": True,
+        }
+
+    monkeypatch.setattr(google_module.id_token, "verify_oauth2_token", fake_verify)
+
+    request = DummyRequest({"credential": "token", "client_id": "test-client"})
+
+    with pytest.raises(exc.BadRequest) as error_info:
+        google_module.login_with_google(request)
+
+    assert "not associated" in str(error_info.value.detail)
+
+
+@pytest.mark.django_db
+def test_login_generates_unique_username(monkeypatch, reload_google):
+    google_module = reload_google()
+
+    f.UserFactory(username="john", email="john@example.com")
+
+    created_users = {}
+
+    def fake_verify(raw_token, request, audience):
+        return {
+            "aud": "test-client",
+            "iss": "accounts.google.com",
+            "email": "john@upc.edu",
+            "email_verified": True,
+            "given_name": "John",
+            "family_name": "Smith",
+        }
+
+    def fake_auth_response(user):
+        created_users["instance"] = user
+        return {"auth_token": "dummy", "refresh": "dummy"}
+
+    monkeypatch.setattr(google_module.id_token, "verify_oauth2_token", fake_verify)
+    monkeypatch.setattr(google_module, "make_auth_response_data", fake_auth_response)
+
+    request = DummyRequest({"credential": "token", "client_id": "test-client"})
+
+    google_module.login_with_google(request)
+
+    user_model = get_user_model()
+    user = user_model.objects.get(email="john@upc.edu")
+    assert created_users["instance"].username == "john-1"
+    assert user.username == "john-1"
+
+
+@pytest.mark.django_db
+def test_login_rejects_unexpected_audience(monkeypatch, reload_google):
+    google_module = reload_google()
+
+    def fake_verify(raw_token, request, audience):
+        return {
+            "aud": "other-client",
+            "iss": "accounts.google.com",
+            "email": "john@upc.edu",
+            "email_verified": True,
+        }
+
+    monkeypatch.setattr(google_module.id_token, "verify_oauth2_token", fake_verify)
+
+    request = DummyRequest({"credential": "token", "client_id": "test-client"})
+
+    with pytest.raises(exc.BadRequest) as error_info:
+        google_module.login_with_google(request)
+
+    assert "Invalid Google credential" in str(error_info.value.detail)


### PR DESCRIPTION
This pull request introduces Google Single Sign-On (SSO) as the exclusive authentication method for the backend, replacing classic username/password login and registration flows. It adds a robust integration with Google Identity Services, enforces domain restrictions, and disables legacy authentication endpoints. Configuration is now environment-driven and well-documented for deployment and operational clarity.

**Google SSO Integration and Configuration**

* Added a new `google` auth plugin to `/api/v1/auth` that verifies Google ID tokens using the official `google-auth` library, with domain restrictions and auto-provisioning of users based on configuration. [[1]](diffhunk://#diff-d1e8401683d9d919c889afaa18c40569bd6f2df21d14f511b1088d116db16561R1-R67) [[2]](diffhunk://#diff-dfd23056a75dd2649dbf2cab2361e3a1431ba8b6230db96056a3de3cd00c86c4R1-R177)
* New environment variables and helper functions in `settings/common.py` (`GOOGLE_AUTH_CLIENT_IDS`, `GOOGLE_AUTH_ALLOWED_DOMAINS`, `GOOGLE_AUTH_AUTO_CREATE`, `GOOGLE_AUTH_ENABLED`) allow flexible control of SSO behavior; defaults are suitable for UPC development. [[1]](diffhunk://#diff-4c53754f2b7258a79fbcd4ad49161f601dcb69ee6b35ac5ef902e6e8fecf2b38R14-R29) [[2]](diffhunk://#diff-4c53754f2b7258a79fbcd4ad49161f601dcb69ee6b35ac5ef902e6e8fecf2b38R63-R82)

**Authentication Flow Changes**

* Disabled classic login and registration endpoints (`login`, `public_register`, `private_register_for_new_user`) by raising controlled `400 Bad Request` errors; original code is commented for reference. [[1]](diffhunk://#diff-2f81cb38b4e3beb9e19483528833ef82fe3890fec1522382a158e6fb0a82e41bL69-R103) [[2]](diffhunk://#diff-2f81cb38b4e3beb9e19483528833ef82fe3890fec1522382a158e6fb0a82e41bL156-R205) [[3]](diffhunk://#diff-2f81cb38b4e3beb9e19483528833ef82fe3890fec1522382a158e6fb0a82e41bL186-R244)
* Dynamic plugin loader in `taiga/auth/services.py` ensures Google auth is registered only when enabled and properly configured, with clear error handling for misconfiguration.

**Dependencies and Documentation**

* Added `google-auth==2.29.0` and related dependencies to `requirements.in`/`requirements.txt` for token validation.
* Comprehensive documentation in `docs/pol_alcoverro/LoginGoogle.md` covers configuration, operational steps, licensing, and error handling for the new SSO flow.

**Testing and Environment Adjustments**

* Updated database password for local development to `taigaupc` in both `settings/common.py` and test config. [[1]](diffhunk://#diff-4c53754f2b7258a79fbcd4ad49161f601dcb69ee6b35ac5ef902e6e8fecf2b38L30-R46) [[2]](diffhunk://#diff-c088fe176a16b316cbeeff2b042480c85b0c1d95886eb310352506a541c1460eL56-R57)
* Skipped legacy auth resource tests, since classic login and registration are now disabled in this build.

These changes ensure secure, streamlined authentication via Google, simplify user management, and provide clear operational guidance for maintainers and deployers.